### PR TITLE
Bevy `0.11` Migration - Merge branch 'release-v0.3.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [![v0.3.0](https://img.shields.io/badge/v0.3.0-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)
 [![**Full Commits History**](https://img.shields.io/badge/GitHubLog-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)](https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)
 
+- [Migration Guide Bevy 0.10 -> 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/)
+- *not needed* [Changelog Bevy Rapier 0.21 -> 0.22](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0220-10-july-2023)
+
+### [Bevy 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/) Migration
+
+- ECS
+  - `in_set(OnUpdate(*))` -> `run_if(in_state(*))`
+  - Add the `#[derive(Event)]` macro for events.
+  - Allow tuples and single plugins in `add_plugins`, deprecate `add_plugin`
+  - [Schedule-First: the new and improved `add_systems`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#schedule-first-the-new-and-improved-add-systems)
+- UI
+  - Flatten UI Style properties that use Size + remove Size
+    - The `size`, `min_size`, `max_size`, and `gap` properties have been replaced by the `width`, `height`, `min_width`, `min_height`, `max_width`, `max_height`, `row_gap`, and `column_gap` properties. Use the new properties instead.
+  - [Remove `Val::Undefinded`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#remove-val-undefined)
+    - `Val::Undefined` has been removed. Bevy UI’s behaviour with default values should remain the same.
+    The default values of `UiRect`’s fields have been changed to `Val::Px(0.)`.
+    `Style`’s position field has been removed. Its `left`, `right`, `top` and `bottom` fields have been added to `Style` directly.
+    For the `size`, `margin`, `border`, and `padding` fields of `Style`, `Val::Undefined` should be replaced with `Val::Px(0.)`.
+    For the `min_size`, `max_size`, `left`, `right`, `top` and `bottom` fields of `Style`, `Val::Undefined` should be replaced with `Val::Auto`
+  - [Rename keys like `LAlt` to `AltLeft`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#rename-keys-like-lalt-to-altleft)
+  - [Delay asset hot reloading](https://bevyengine.org/learn/migration-guides/0.10-0.11/#delay-asset-hot-reloading)
+  - [`Interaction::Clicked` replaced by `Interaction::Pressed`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#rename-interaction-clicked-interaction-pressed)
+- Dependencies
+  - bevy_rapier_2d `0.22`
+  - bevy-inspector-egui `0.20`
+
 ### [Bevy 0.10](https://bevyengine.org/learn/migration-guides/0.9-0.10/) Migration
 
 - Dependencies
   - remove the `dynamic` feature fr
-  - bevy-inspector-egui 0.18
-  - bevy_rapier2d [0.21](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0210--07-march-2023)
+  - bevy-inspector-egui `0.18`
+  - bevy_rapier2d `0.21` - [changelog](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0210--07-march-2023)
     - feature `debug-render` change to `debug-render-2d`
 - ECS
   - [Migrate engine to Schedule v3 (stageless)](https://bevyengine.org/learn/migration-guides/0.9-0.10/#migrate-engine-to-schedule-v3-stageless)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Migration Guide Bevy 0.10 -> 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/)
 - *not needed* [Changelog Bevy Rapier 0.21 -> 0.22](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0220-10-july-2023)
 
+### Added
+
+- [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/fabinistere/cats_destroyer_2000#license)
+
 ### [Bevy 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/) Migration
 
 - ECS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Bevy Migration - [v0.3.0](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0) - 2024-08-06
+
+[![v0.3.0](https://img.shields.io/badge/v0.3.0-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)
+[![**Full Commits History**](https://img.shields.io/badge/GitHubLog-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)](https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)
+
+### [Bevy 0.10](https://bevyengine.org/learn/migration-guides/0.9-0.10/) Migration
+
+- Dependencies
+  - remove the `dynamic` feature fr
+  - bevy-inspector-egui 0.18
+  - bevy_rapier2d [0.21](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0210--07-march-2023)
+    - feature `debug-render` change to `debug-render-2d`
+- ECS
+  - [Migrate engine to Schedule v3 (stageless)](https://bevyengine.org/learn/migration-guides/0.9-0.10/#migrate-engine-to-schedule-v3-stageless)
+  - [System sets (Bevy 0.9)](https://bevyengine.org/learn/migration-guides/0.9-0.10/#system-sets-bevy-0-9)
+  - [States](https://bevyengine.org/learn/migration-guides/0.9-0.10/#states)
+  - Replace `RemovedComponents<T>` backing with `Events<Entity>`
+- UI
+  - [Windows as Entities](https://bevyengine.org/learn/migration-guides/0.9-0.10/#windows-as-entities)
+
 ## Final Cinematic - [v0.2](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2) - 2023-06-11
 
 [![v0.2](https://img.shields.io/badge/v0.2-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Final Cinematic - [v0.2](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2) - 2023-06-11
+
+[![v0.2](https://img.shields.io/badge/v0.2-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.2)
+
+## Add
+
+- End cinematic
+- WebAssembly
+
+## Must Have
+
+- Back to jail (when touched by a enemy)
+
+## Should Have
+
+- UI for the Tablet
+- Vision Feature
+  - Tile per Tile
+  - Can only interact with seen entities.
+  - Entities can be seen by camera, any mindControled entity (including the player)
+- Music
+- SFX
+- Start Menu
+
+## Level 1000 - [v0.1](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.1) - 2023-02-12
+
+[![v0.1](https://img.shields.io/badge/v0.1-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.1)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.1)
+
+## Currently Have
+
+- NPC
+  - triggered by player if around (and in the same area)
+  - Movement
+- Player
+  - Basic Movement
+- Tablet
+  - MindControl
+    - Take the body of another cat
+    - Stun after a short time after mindctrl
+  - Hack
+    - Open One door
+    - Can't Hack while mindcontrol
+- Map
+  - Hitbox
+  - Doors
+    - Closed
+  - Physical Button
+    - which opens front and exit doors
+
+## Must Have
+
+- Start/End cinematic
+- Back to jail (when touched by a enemy)
+- Web Exe
+
+## Should Have
+
+- UI for the Tablet
+- Vision Feature
+  - Tile per Tile
+  - Can only interact with seen entities.
+  - Entities can be seen by camera, any mindControled entity (including the player)
+- Music
+- SFX
+- Start Menu
+
+## Blue Cat Flex - [v0.0](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.0) - 2023-02-03
+
+[![v0.0](https://img.shields.io/badge/v0.0-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.0)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.0)
+
+- Simple Animation
+- Blue Cat Flexing in the center
+
+![fast_blue_cat](https://user-images.githubusercontent.com/73140258/216720606-6e8f7768-3170-4956-a5d1-5124741783aa.gif)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cats_destroyer_2000"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Olf EPAIN aka Wabtey <wabtey@disroot.org>", "???"]
 edition = "2021"
 
@@ -8,10 +8,9 @@ edition = "2021"
 
 [dependencies]
 
-bevy = { version = "0.9", features = ["dynamic"] }
-bevy-inspector-egui = "0.15"
-# bevy_tweening = "0.6"
-bevy_rapier2d = { version = "0.19", features = ["simd-stable", "debug-render"] }
+bevy = "0.10"
+bevy-inspector-egui = "0.18"
+bevy_rapier2d = { version = "0.21", features = ["simd-stable", "debug-render-2d"] }
 
 image = "0.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 
 [dependencies]
 
-bevy = "0.10"
-bevy-inspector-egui = "0.18"
-bevy_rapier2d = { version = "0.21", features = ["simd-stable", "debug-render-2d"] }
+bevy = "0.11"
+bevy-inspector-egui = "0.20"
+bevy_rapier2d = { version = "0.22", features = ["simd-stable", "debug-render-2d"] }
 
 image = "0.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cats_destroyer_2000"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Olf EPAIN aka Wabtey <wabtey@disroot.org>", "???"]
 edition = "2021"
 

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 F.A.B.I.E.N. Game Studio
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023 F.A.B.I.EN. Game Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 F.A.B.I.EN. Game Studio
+Copyright (c) 2024 F.A.B.I.E.N. Game Studio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/characters/effects/mod.rs
+++ b/src/characters/effects/mod.rs
@@ -1,4 +1,3 @@
-use crate::characters::effects::style::{add_dazed_effect, animate_dazed_effect};
 use bevy::prelude::*;
 
 pub mod style;
@@ -6,12 +5,9 @@ pub mod style;
 pub struct EffectsPlugin;
 
 impl Plugin for EffectsPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app
             // -- Style --
-            .add_system(add_dazed_effect)
-            .add_system(animate_dazed_effect)
-            ;
+            .add_systems((style::add_dazed_effect, style::animate_dazed_effect));
     }
 }

--- a/src/characters/effects/mod.rs
+++ b/src/characters/effects/mod.rs
@@ -8,6 +8,9 @@ impl Plugin for EffectsPlugin {
     fn build(&self, app: &mut App) {
         app
             // -- Style --
-            .add_systems((style::add_dazed_effect, style::animate_dazed_effect));
+            .add_systems(
+                Update,
+                (style::add_dazed_effect, style::animate_dazed_effect),
+            );
     }
 }

--- a/src/characters/effects/style.rs
+++ b/src/characters/effects/style.rs
@@ -23,7 +23,7 @@ pub fn add_dazed_effect(
         // TODO: polish - floating Stars above their head
 
         // whatever the entity
-        commands.entity(entity).add_children(|parent| {
+        commands.entity(entity).with_children(|parent| {
             parent.spawn((
                 SpriteSheetBundle {
                     sprite: TextureAtlasSprite {

--- a/src/characters/mod.rs
+++ b/src/characters/mod.rs
@@ -1,7 +1,5 @@
 use bevy::prelude::*;
 
-use self::{effects::EffectsPlugin, npcs::NPCsPlugin, player::PlayerPlugin};
-
 pub mod effects;
 pub mod movement;
 pub mod npcs;
@@ -10,12 +8,11 @@ pub mod player;
 pub struct CharactersPlugin;
 
 impl Plugin for CharactersPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app
-            .add_plugin(NPCsPlugin)
-            .add_plugin(PlayerPlugin)
-            .add_plugin(EffectsPlugin)
-            ;
+        app.add_plugins((
+            npcs::NPCsPlugin,
+            player::PlayerPlugin,
+            effects::EffectsPlugin,
+        ));
     }
 }

--- a/src/characters/movement.rs
+++ b/src/characters/movement.rs
@@ -8,21 +8,11 @@ use crate::TILE_SIZE;
 #[derive(Component)]
 pub struct CharacterHitbox;
 
-/// Is it a good habit to seperate
-/// - Dazed
-/// - DazeTimer
-/// ?
 #[derive(Component)]
 pub struct Dazed {
     /// should be a non-repeating timer
     pub timer: Timer,
 }
-
-// #[derive(Component)]
-// pub struct DazeTimer {
-//     /// should be a non-repeating timer
-//     pub timer: Timer,
-// }
 
 #[derive(Component, Deref, DerefMut)]
 pub struct Speed(pub f32);

--- a/src/characters/npcs/aggression.rs
+++ b/src/characters/npcs/aggression.rs
@@ -39,6 +39,7 @@ use super::{
 ///     - remove DetectionBehavior from the entity
 ///     - insert PursuitBehavior into the entity
 ///     - insert the Target into the entity
+#[derive(Event)]
 pub struct EngagePursuitEvent {
     npc_entity: Entity,
     target_entity: Entity,

--- a/src/characters/npcs/aggression.rs
+++ b/src/characters/npcs/aggression.rs
@@ -32,7 +32,8 @@ use super::{
 /// Happens when:
 ///   - npc::aggression::player_detection
 ///     - An npc detected a enemy
-///     in the same Area
+///       in the same Area
+///
 /// Read in
 ///   - npc::aggression::add_pursuit_urge
 ///     - remove DetectionBehavior from the entity
@@ -142,9 +143,9 @@ pub fn reset_aggro(
 
     mut new_direction_event: EventWriter<NewDirectionEvent>,
 ) {
-    for ev in reset_aggro_event.iter() {
-        commands.entity(ev.npc).remove::<ChaseBehavior>();
-        commands.entity(ev.npc).insert(WalkBehavior);
-        new_direction_event.send(NewDirectionEvent(ev.npc));
+    for ResetAggroEvent { npc } in reset_aggro_event.iter() {
+        commands.entity(*npc).remove::<ChaseBehavior>();
+        commands.entity(*npc).insert(WalkBehavior);
+        new_direction_event.send(NewDirectionEvent(*npc));
     }
 }

--- a/src/characters/npcs/mod.rs
+++ b/src/characters/npcs/mod.rs
@@ -67,7 +67,7 @@ fn spawn_characters(mut commands: Commands, cats: Res<CatSheet>) {
                 visibility: Visibility { is_visible: false },
                 ..Default::default()
             },
-            Name::new(format!("WayPoint for Black Cat")),
+            Name::new("WayPoint for Black Cat"),
         ))
         .id();
 

--- a/src/characters/npcs/mod.rs
+++ b/src/characters/npcs/mod.rs
@@ -4,13 +4,8 @@ use bevy_rapier2d::prelude::*;
 use crate::{
     characters::movement::{CharacterHitbox, MovementBundle, Speed},
     characters::npcs::{
-        aggression::{
-            add_pursuit_urge, player_detection, reset_aggro, DetectionSensor, EngagePursuitEvent,
-        },
-        movement::{
-            daze_wait, give_new_direction_event, npc_chase, npc_walk, npc_walk_to,
-            NewDirectionEvent, ResetAggroEvent, WalkBehavior,
-        },
+        aggression::{DetectionSensor, EngagePursuitEvent},
+        movement::{NewDirectionEvent, ResetAggroEvent, WalkBehavior},
     },
     constants::character::{
         npc::{movement::BLACK_CAT_STARTING_POSITION, *},
@@ -37,15 +32,19 @@ impl Plugin for NPCsPlugin {
             .add_event::<ResetAggroEvent>()
             .add_startup_system(spawn_characters)
             // -- Movement --
-            .add_system(npc_walk_to)
-            .add_system(npc_walk)
-            .add_system(npc_chase)
-            .add_system(reset_aggro)
-            .add_system(daze_wait)
-            .add_system(give_new_direction_event)
+            .add_systems((
+                movement::npc_walk_to,
+                movement::npc_walk,
+                movement::npc_chase,
+                movement::daze_wait,
+                movement::give_new_direction_event,
+            ))
             // -- Aggression --
-            .add_system(player_detection)
-            .add_system(add_pursuit_urge)
+            .add_systems((
+                aggression::player_detection,
+                aggression::add_pursuit_urge,
+                aggression::reset_aggro,
+            ))
             ;
     }
 }

--- a/src/characters/npcs/mod.rs
+++ b/src/characters/npcs/mod.rs
@@ -76,7 +76,6 @@ fn spawn_characters(mut commands: Commands, cats: Res<CatSheet>) {
             SpriteSheetBundle {
                 sprite: TextureAtlasSprite {
                     index: BLACK_CAT_STARTING_ANIM,
-                    flip_x: true,
                     ..default()
                 },
                 texture_atlas: cats.0.clone(),

--- a/src/characters/npcs/mod.rs
+++ b/src/characters/npcs/mod.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::Inspectable;
 use bevy_rapier2d::prelude::*;
 
 use crate::{
@@ -51,7 +50,7 @@ impl Plugin for NPCsPlugin {
     }
 }
 
-#[derive(Component, Inspectable)]
+#[derive(Component, Reflect)]
 pub struct NPC;
 
 fn spawn_characters(mut commands: Commands, cats: Res<CatSheet>) {
@@ -64,8 +63,8 @@ fn spawn_characters(mut commands: Commands, cats: Res<CatSheet>) {
                     BLACK_CAT_STARTING_POSITION.1 - 50.,
                     0.,
                 )),
-                visibility: Visibility { is_visible: false },
-                ..Default::default()
+                visibility: Visibility::Hidden,
+                ..default()
             },
             Name::new("WayPoint for Black Cat"),
         ))

--- a/src/characters/npcs/mod.rs
+++ b/src/characters/npcs/mod.rs
@@ -24,28 +24,26 @@ pub mod movement;
 pub struct NPCsPlugin;
 
 impl Plugin for NPCsPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app
-            .add_event::<NewDirectionEvent>()
+        app.add_event::<NewDirectionEvent>()
             .add_event::<EngagePursuitEvent>()
             .add_event::<ResetAggroEvent>()
-            .add_startup_system(spawn_characters)
-            // -- Movement --
-            .add_systems((
-                movement::npc_walk_to,
-                movement::npc_walk,
-                movement::npc_chase,
-                movement::daze_wait,
-                movement::give_new_direction_event,
-            ))
-            // -- Aggression --
-            .add_systems((
-                aggression::player_detection,
-                aggression::add_pursuit_urge,
-                aggression::reset_aggro,
-            ))
-            ;
+            .add_systems(Startup, spawn_characters)
+            .add_systems(
+                Update,
+                (
+                    // -- Movement --
+                    movement::npc_walk_to,
+                    movement::npc_walk,
+                    movement::npc_chase,
+                    movement::daze_wait,
+                    movement::give_new_direction_event,
+                    // -- Aggression --
+                    aggression::player_detection,
+                    aggression::add_pursuit_urge,
+                    aggression::reset_aggro,
+                ),
+            );
     }
 }
 

--- a/src/characters/npcs/movement.rs
+++ b/src/characters/npcs/movement.rs
@@ -20,7 +20,8 @@ pub struct ChaseBehavior;
 /// DOC
 // pub struct FreezeEvent;
 
-/// DOC
+/// DOC: describe NewDirectionEvent
+#[derive(Event)]
 pub struct NewDirectionEvent(pub Entity);
 
 /// Happens in
@@ -33,6 +34,7 @@ pub struct NewDirectionEvent(pub Entity);
 ///     - Remove ChaseBehavior
 ///       Insert WalkBehavior
 ///       Ask for a new destination
+#[derive(Event)]
 pub struct ResetAggroEvent {
     pub npc: Entity,
 }

--- a/src/characters/npcs/movement.rs
+++ b/src/characters/npcs/movement.rs
@@ -2,7 +2,10 @@ use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
 use crate::{
-    characters::{effects::style::DazeAnimation, movement::{Dazed, Speed}},
+    characters::{
+        effects::style::DazeAnimation,
+        movement::{Dazed, Speed},
+    },
     characters::{npcs::NPC, player::Player},
     constants::character::npc::movement::BLACK_CAT_STARTING_POSITION,
     tablet::mind_control::MindControled,
@@ -212,8 +215,8 @@ pub fn give_new_direction_event(
                                         BLACK_CAT_STARTING_POSITION.1 - 50.,
                                         0.,
                                     )),
-                                    visibility: Visibility { is_visible: false },
-                                    ..Default::default()
+                                    visibility: Visibility::Hidden,
+                                    ..default()
                                 },
                                 Name::new(format!("WayPoint for {}", name)),
                             ))
@@ -239,7 +242,10 @@ pub fn daze_wait(
     mut commands: Commands,
 
     time: Res<Time>,
-    mut npc_query: Query<(Entity, &mut Dazed, &mut Velocity, &Children, &Name), (With<NPC>, Without<Player>)>,
+    mut npc_query: Query<
+        (Entity, &mut Dazed, &mut Velocity, &Children, &Name),
+        (With<NPC>, Without<Player>),
+    >,
     daze_effect_query: Query<Entity, With<DazeAnimation>>,
 ) {
     for (npc, mut daze_timer, mut _rb_vel, children, name) in npc_query.iter_mut() {

--- a/src/characters/npcs/movement.rs
+++ b/src/characters/npcs/movement.rs
@@ -27,23 +27,18 @@ pub struct NewDirectionEvent(pub Entity);
 ///   - npc::movement::npc_chase
 ///     - target in ChaseBehavior is not a player
 ///     - target is reached
+///
 /// Read in
 ///   - npc::movement::reset_aggro
 ///     - Remove ChaseBehavior
-///     Insert WalkBehavior
-///     Ask for a new destination
+///       Insert WalkBehavior
+///       Ask for a new destination
 pub struct ResetAggroEvent {
     pub npc: Entity,
 }
 
-#[derive(Clone, Copy, Component)]
+#[derive(Clone, Copy, Default, Component)]
 pub struct Target(pub Option<Entity>);
-
-impl Default for Target {
-    fn default() -> Self {
-        Target { 0: None }
-    }
-}
 
 /// # Note
 ///
@@ -197,11 +192,11 @@ pub fn give_new_direction_event(
     // REFACTOR: FOR NOW target can't be NPC - conflictual queries
     mut target_query: Query<(Entity, &mut Transform), (Without<Player>, Without<NPC>)>,
 ) {
-    for event in new_direction_event.iter() {
-        match npc_query.get_mut(event.0) {
-            Err(e) => warn!("{:?}", e),
+    for NewDirectionEvent(npc) in new_direction_event.iter() {
+        match npc_query.get_mut(*npc) {
+            Err(e) => warn!("the entity {npc:?} is not a npc. {e:?}"),
             Ok((_, npc_transform, mut target, name)) => {
-                // creation of a Waypoint
+                // creation of a Waypoint if not pursing
                 match target_query.get_mut(target.0.unwrap()) {
                     Err(e) => {
                         // resetAggro ?

--- a/src/characters/player.rs
+++ b/src/characters/player.rs
@@ -45,7 +45,6 @@ fn spawn_player(mut commands: Commands, cats: Res<CatSheet>) {
             SpriteSheetBundle {
                 sprite: TextureAtlasSprite {
                     index: BLUE_CAT_STARTING_ANIM,
-                    flip_x: true,
                     ..default()
                 },
                 texture_atlas: cats.0.clone(),

--- a/src/characters/player.rs
+++ b/src/characters/player.rs
@@ -9,7 +9,6 @@ use crate::{
     tablet::mind_control::MindControled,
 };
 use bevy::prelude::*;
-use bevy_inspector_egui::Inspectable;
 use bevy_rapier2d::prelude::*;
 
 pub struct PlayerPlugin;
@@ -23,7 +22,7 @@ impl Plugin for PlayerPlugin {
     }
 }
 
-#[derive(Component, Inspectable)]
+#[derive(Component, Reflect)]
 pub struct Player;
 
 #[derive(Component)]

--- a/src/characters/player.rs
+++ b/src/characters/player.rs
@@ -14,11 +14,8 @@ use bevy_rapier2d::prelude::*;
 pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app .add_startup_system(spawn_player)
-            .add_system(player_idle)
-            ;
+        app.add_startup_system(spawn_player).add_system(player_idle);
     }
 }
 

--- a/src/characters/player.rs
+++ b/src/characters/player.rs
@@ -15,7 +15,8 @@ pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(spawn_player).add_system(player_idle);
+        app.add_systems(Startup, spawn_player)
+            .add_systems(Update, player_idle);
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -20,7 +20,7 @@ pub mod character {
 
     pub const CHAR_HITBOX_HEIGHT: f32 = 1.5 * CHAR_SCALE;
     pub const CHAR_HITBOX_WIDTH: f32 = 5. * CHAR_SCALE;
-    pub const CHAR_HITBOX_Y_OFFSET: f32 = -4. * CHAR_SCALE;
+    pub const CHAR_HITBOX_Y_OFFSET: f32 = -3.5 * CHAR_SCALE;
     pub const CHAR_HITBOX_Z_OFFSET: f32 = 0. * CHAR_SCALE;
 
     pub mod npc {
@@ -33,8 +33,8 @@ pub mod character {
         pub mod movement {
             use crate::constants::character::CHAR_Z;
 
-            pub const BLUE_CAT_STARTING_POSITION: (f32, f32, f32) = (5., -48., CHAR_Z);
-            pub const BLACK_CAT_STARTING_POSITION: (f32, f32, f32) = (5., 20., CHAR_Z);
+            pub const BLUE_CAT_STARTING_POSITION: (f32, f32, f32) = (-5., -48., CHAR_Z);
+            pub const BLACK_CAT_STARTING_POSITION: (f32, f32, f32) = (-5., 20., CHAR_Z);
         }
     }
 
@@ -50,21 +50,21 @@ pub mod locations {
 
     pub const LEVEL_Z: f32 = 3.;
     pub const LEVEL_POSITION: (f32, f32, f32) = (0., 0., LEVEL_Z);
-    pub const LEVEL_SCALE: (f32, f32, f32) = (-1., 1., 1.);
-    
+    pub const LEVEL_SCALE: (f32, f32, f32) = (1., 1., 1.);
+
     pub const FLOOR_Z: f32 = 1.;
     pub const FLOOR_POSITION: (f32, f32, f32) = (0., 0., FLOOR_Z);
-    
+
     pub mod level_one {
         use super::LEVEL_Z;
-        
-        pub const IN_DOOR_POSITION: (f32, f32, f32) = (5., -36., LEVEL_Z);
-        pub const ALT_DOOR_POSITION: (f32, f32, f32) = (-2.5, 6., LEVEL_Z);
-        pub const OUT_DOOR_POSITION: (f32, f32, f32) = (5., 36., LEVEL_Z);
-        
-        pub const BUTTON_POSITION: (f32, f32, f32) = (-24., 6., LEVEL_Z - 1.);
-        pub const BUTTON_HITBOX_X_OFFSET: (f32, f32, f32) = (3., 0., 0.);
-        pub const BUTTON_SENSOR_POSITION: (f32, f32, f32) = (-25.5, 6., LEVEL_Z);
+
+        pub const IN_DOOR_POSITION: (f32, f32, f32) = (-5., -36., LEVEL_Z);
+        pub const ALT_DOOR_POSITION: (f32, f32, f32) = (2.5, 6., LEVEL_Z);
+        pub const OUT_DOOR_POSITION: (f32, f32, f32) = (-5., 36., LEVEL_Z);
+
+        pub const BUTTON_POSITION: (f32, f32, f32) = (24., 6., LEVEL_Z - 1.);
+        pub const BUTTON_HITBOX_X_OFFSET: (f32, f32, f32) = (-3., 0., 0.);
+        pub const BUTTON_SENSOR_POSITION: (f32, f32, f32) = (25.5, 6., LEVEL_Z);
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -11,7 +11,7 @@ pub struct DebugPlugin;
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut App) {
         if cfg!(debug_assertions) {
-            app.add_plugin(WorldInspectorPlugin::new())
+            app.add_plugins(WorldInspectorPlugin::new())
                 .register_type::<NPC>()
                 .register_type::<CharacterLocation>()
                 .register_type::<LevelOneLocation>()

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::{RegisterInspectable, WorldInspectorPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use crate::{
     characters::npcs::NPC,
@@ -9,13 +9,12 @@ use crate::{
 pub struct DebugPlugin;
 
 impl Plugin for DebugPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         if cfg!(debug_assertions) {
             app.add_plugin(WorldInspectorPlugin::new())
-                .register_inspectable::<NPC>()
-                .register_inspectable::<CharacterLocation>()
-                .register_inspectable::<LevelOneLocation>()
+                .register_type::<NPC>()
+                .register_type::<CharacterLocation>()
+                .register_type::<LevelOneLocation>()
 
                 // UI
                 ;

--- a/src/locations/cinematics/mod.rs
+++ b/src/locations/cinematics/mod.rs
@@ -33,7 +33,8 @@ pub fn cinematic_camera(
     camera_transform.translation.x = 0.;
     camera_transform.translation.y = 3.;
 
-    camera_transform.scale = Vec3::new(1.4, 1.4, 1.)
+    camera_transform.scale = Vec3::new(1.3, 1.3, 1.3)
+    // TODO: adpat the camera to be centered on the endcinematic
 }
 
 pub fn spawn_cinematic_final(
@@ -115,7 +116,7 @@ pub fn spawn_cinematic_final(
         SpriteSheetBundle {
             texture_atlas: cat_escape_atlas_handle.clone(),
             transform: Transform {
-                translation: Vec3::from((12., -12., 9.)),
+                translation: Vec3::from((-12., -12., 9.)),
                 scale: Vec3::from(LEVEL_SCALE),
                 ..default()
             },
@@ -131,7 +132,6 @@ pub fn spawn_cinematic_final(
 }
 
 // TODO: spawn a Quit button after x seconds
-// TODO: adpat the camera to be centered on the endcinematic
 
 // LEVEL_SCALE
 

--- a/src/locations/cinematics/mod.rs
+++ b/src/locations/cinematics/mod.rs
@@ -5,9 +5,9 @@ use bevy::prelude::*;
 
 use crate::{
     characters::npcs::NPC,
-    constants::{FRAME_TIME, locations::LEVEL_SCALE, cinematics::*},
-    tablet::mind_control::MindControled,
+    constants::{cinematics::*, locations::LEVEL_SCALE, FRAME_TIME},
     spritesheet::AnimationTimer,
+    tablet::mind_control::MindControled,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -16,18 +16,13 @@ use crate::{
 
 /// Marker for the final cat sprite anim
 #[derive(Component)]
-struct FinalFormCat;
+pub struct Clouds;
 
 /// Marker for the final cat sprite anim
 #[derive(Component)]
-pub struct Clouds;
-
-#[derive(Component)]
 pub struct PlayerHusk;
 
-pub fn cinematic_camera(
-    mut camera_query: Query<&mut Transform, With<Camera>>,
-) {
+pub fn cinematic_camera(mut camera_query: Query<&mut Transform, With<Camera>>) {
     let mut camera_transform = camera_query.single_mut();
 
     camera_transform.translation.x = 0.;
@@ -94,6 +89,7 @@ pub fn spawn_cinematic_final(
         Name::new("Cinematics - Mountain Lab"),
     ));
 
+    // BUG: if an enemy manage to cross the win sensor without the mind controlled the wrong cinematic will proc
     let cat_escape_image = if blue_cat_controlled_query.is_empty() {
         info!("EasterEgg: Black Cat Escaped");
         asset_server.load("textures/cinematics/final/black-cat-sheet.png")
@@ -102,14 +98,8 @@ pub fn spawn_cinematic_final(
         asset_server.load("textures/cinematics/final/blue-cat-sheet.png")
     };
 
-    let cat_escape_atlas = TextureAtlas::from_grid(
-        cat_escape_image,
-        Vec2::from((19., 17.)),
-        14,
-        1,
-        None,
-        None,
-    );
+    let cat_escape_atlas =
+        TextureAtlas::from_grid(cat_escape_image, Vec2::from((19., 17.)), 14, 1, None, None);
     let cat_escape_atlas_handle = texture_atlases.add(cat_escape_atlas);
 
     commands.spawn((
@@ -138,20 +128,13 @@ pub fn spawn_cinematic_final(
 /// Infinitly loop the clouds
 pub fn animate_clouds(
     time: Res<Time>,
-    mut clouds_query: Query<
-        (
-            &mut AnimationTimer,
-            &mut Transform,
-        ),
-        With<Clouds>,
-    >,
+    mut clouds_query: Query<(&mut AnimationTimer, &mut Transform), With<Clouds>>,
 ) {
     for (mut timer, mut transform) in &mut clouds_query {
         timer.tick(time.delta());
 
         if timer.just_finished() {
-            transform.translation.x = 
-            if transform.translation.x == CLOUDS_LIMIT {
+            transform.translation.x = if transform.translation.x == CLOUDS_LIMIT {
                 CLOUDS_RESET
             } else {
                 // IDEA: can be smoother if - 0.1 and faster timer

--- a/src/locations/level_one/doors.rs
+++ b/src/locations/level_one/doors.rs
@@ -24,7 +24,8 @@ pub enum DoorState {
 #[derive(Component)]
 pub struct ExitDoor;
 
-/// DOC
+/// DOC: describe OpenDoorEvent
+#[derive(Event)]
 pub struct OpenDoorEvent(pub Entity);
 
 /// Open the end of the level

--- a/src/locations/level_one/mod.rs
+++ b/src/locations/level_one/mod.rs
@@ -156,66 +156,66 @@ fn setup_level_one(
                     // Collider draw by hand...
                     parent.spawn((
                         Collider::cuboid(21., 1.5),
-                        Transform::from_xyz(5., -57., 0.),
+                        Transform::from_xyz(-5., -57., 0.),
                         Name::new("Entry Lower Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(1.5, 12.),
-                        Transform::from_xyz(24.5, -46.5, 0.),
+                        Transform::from_xyz(-24.5, -46.5, 0.),
                         Name::new("Entry Left Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(1.5, 12.),
-                        Transform::from_xyz(-14.5, -46.5, 0.),
+                        Transform::from_xyz(14.5, -46.5, 0.),
                         Name::new("Entry Right Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(7.5, 1.5),
-                        Transform::from_xyz(18.5, -36., 0.),
+                        Transform::from_xyz(-18.5, -36., 0.),
                         Name::new("Entry Top Left Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(7.5, 1.5),
-                        Transform::from_xyz(-8.5, -36., 0.),
+                        Transform::from_xyz(8.5, -36., 0.),
                         Name::new("Entry Top Right Hitbox"),
                     ));
                     // --- Corridor ---
                     parent.spawn((
                         Collider::cuboid(1.5, 44.5),
-                        Transform::from_xyz(12.5, 10., 0.),
+                        Transform::from_xyz(-12.5, 10., 0.),
                         Name::new("Corridor Left Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(1.5, 16.5),
-                        Transform::from_xyz(-2.5, -18., 0.),
+                        Transform::from_xyz(2.5, -18., 0.),
                         Name::new("Corridor Right Bottom Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(1.5, 20.5),
-                        Transform::from_xyz(-2.5, 34., 0.),
+                        Transform::from_xyz(2.5, 34., 0.),
                         Name::new("Corridor Right Top Hitbox"),
                     ));
                     // --- Elevator ---
                     // Which is the two Exit and Front Door
                     parent.spawn((
                         Collider::cuboid(6., 1.5),
-                        Transform::from_xyz(5., 53., 0.),
+                        Transform::from_xyz(-5., 53., 0.),
                         Name::new("Elevator Top Hitbox"),
                     ));
                     // --- Broom Closet ---
                     parent.spawn((
                         Collider::cuboid(1.5, 7.5),
-                        Transform::from_xyz(-29.5, 6., 0.),
+                        Transform::from_xyz(29.5, 6., 0.),
                         Name::new("Closet Left Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(12., 1.5),
-                        Transform::from_xyz(-16., 15., 0.),
+                        Transform::from_xyz(16., 15., 0.),
                         Name::new("Closet Top Hitbox"),
                     ));
                     parent.spawn((
                         Collider::cuboid(12., 1.5),
-                        Transform::from_xyz(-16., -3., 0.),
+                        Transform::from_xyz(16., -3., 0.),
                         Name::new("Closet Bottom Hitbox"),
                     ));
                     // --- Closet Button Sensor ---
@@ -251,6 +251,7 @@ fn setup_level_one(
                         ..default()
                     },
                     Name::new("Front Door"),
+                    RigidBody::Fixed,
                     Door {
                         current_state: doors::DoorState::Closed,
                     },
@@ -258,14 +259,14 @@ fn setup_level_one(
                 .with_children(|parent| {
                     parent.spawn((
                         Collider::cuboid(6., 1.5),
-                        Transform::default(), // from_xyz(5., -36., 0.),
+                        Transform::default(), // from_xyz(-5., -36., 0.),
                         DoorHitbox,
                         Name::new("Front Door Hitbox"),
                     ));
                     // --- Corridor Sensor ---
                     parent.spawn((
                         Collider::cuboid(6., 3.),
-                        Transform::from_xyz(0., -4.5, 0.),
+                        Transform::from_xyz(0., 4.5, 0.),
                         ActiveEvents::COLLISION_EVENTS,
                         Sensor,
                         LocationSensor {
@@ -276,7 +277,7 @@ fn setup_level_one(
                     // --- SpawnRoom Sensor ---
                     parent.spawn((
                         Collider::cuboid(6., 3.),
-                        Transform::from_xyz(0., 4.5, 0.),
+                        Transform::from_xyz(0., -4.5, 0.),
                         ActiveEvents::COLLISION_EVENTS,
                         Sensor,
                         LocationSensor {
@@ -299,6 +300,7 @@ fn setup_level_one(
                         ..default()
                     },
                     Name::new("Exit Door"),
+                    RigidBody::Fixed,
                     ExitDoor,
                     Door {
                         current_state: doors::DoorState::Closed,
@@ -307,7 +309,7 @@ fn setup_level_one(
                 .with_children(|parent| {
                     parent.spawn((
                         Collider::cuboid(6., 1.5),
-                        Transform::default(), // from_xyz(5., 36., 0.),
+                        Transform::default(), // from_xyz(-5., 36., 0.),
                         DoorHitbox,
                         Name::new("Exit Door Hitbox"),
                     ));
@@ -323,7 +325,7 @@ fn setup_level_one(
                     // --- Corridor Sensor ---
                     parent.spawn((
                         Collider::cuboid(6., 3.),
-                        Transform::from_xyz(0., 4.5, 0.),
+                        Transform::from_xyz(0., -4.5, 0.),
                         ActiveEvents::COLLISION_EVENTS,
                         Sensor,
                         LocationSensor {
@@ -351,6 +353,7 @@ fn setup_level_one(
                         ..default()
                     },
                     Name::new("Closet Door"),
+                    RigidBody::Fixed,
                     Door {
                         current_state: doors::DoorState::Closed,
                     },
@@ -359,7 +362,7 @@ fn setup_level_one(
                 .with_children(|parent| {
                     parent.spawn((
                         Collider::cuboid(1.5, 7.5),
-                        Transform::default(), // from_xyz(-2.5, 6., 0.),
+                        Transform::default(), // from_xyz(2.5, 6., 0.),
                         DoorHitbox,
                         Name::new("Side Door Hitbox"),
                     ));

--- a/src/locations/level_one/mod.rs
+++ b/src/locations/level_one/mod.rs
@@ -35,11 +35,15 @@ impl Plugin for LevelOnePlugin {
             // .add_event::<ResetLevelOneEvent>()
             // .add_event::<EnterLevelOneEvent>()
             // .add_systems((reset_level_one, enter_level_one))
-            .add_systems((setup_level_one, set_up_button).in_schedule(OnEnter(Location::Level1000)))
             .add_systems(
-                (doors::animate_door, doors::open_door_event).in_set(OnUpdate(Location::Level1000)), // .run_if(in_level_one)
+                OnEnter(Location::Level1000),
+                (setup_level_one, set_up_button),
             )
-            .add_system(despawn_level_one.in_schedule(OnExit(Location::Level1000)));
+            .add_systems(
+                Update,
+                (doors::animate_door, doors::open_door_event).run_if(in_state(Location::Level1000)), // .run_if(in_level_one)
+            )
+            .add_systems(OnExit(Location::Level1000), despawn_level_one);
     }
 }
 

--- a/src/locations/level_one/mod.rs
+++ b/src/locations/level_one/mod.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::Inspectable;
 use bevy_rapier2d::prelude::*;
 
 use crate::{
@@ -8,7 +7,7 @@ use crate::{
     locations::{
         level_one::{
             button::PushButton,
-            doors::{animate_door, open_door_event, Door, ExitDoor, OpenDoorEvent}
+            doors::{animate_door, open_door_event, Door, ExitDoor, OpenDoorEvent},
         },
         sensors::WinSensor,
         Location,
@@ -31,40 +30,29 @@ pub mod doors;
 pub struct LevelOnePlugin;
 
 impl Plugin for LevelOnePlugin {
-    #[rustfmt::skip]
+    // #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app .add_event::<OpenDoorEvent>()
+        app.add_event::<OpenDoorEvent>()
             // .add_event::<ResetLevelOneEvent>()
             // .add_event::<EnterLevelOneEvent>()
             // .add_system(reset_level_one)
             // .add_system(enter_level_one)
-            .add_system_set(
-                SystemSet::on_enter(Location::Level1000)
-                    .with_system(setup_level_one)
-                    .with_system(set_up_button)
+            .add_systems((setup_level_one, set_up_button).in_schedule(OnEnter(Location::Level1000)))
+            .add_systems(
+                (animate_door, open_door_event).in_set(OnUpdate(Location::Level1000)), // .run_if(in_level_one)
             )
-            .add_system_set(
-                SystemSet::on_update(Location::Level1000)
-                    // .with_run_criteria(run_if_in_level_one)
-                    .with_system(animate_door)
-                    .with_system(open_door_event)
-            )
-            .add_system_set(
-                SystemSet::on_exit(Location::Level1000)
-                    .with_system(despawn_level_one)
-            )
-            ;
+            .add_system(despawn_level_one.in_schedule(OnExit(Location::Level1000)));
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Hash, Copy, Inspectable)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Copy, Reflect)]
 pub enum LevelOneLocation {
     SpawnRoom,
     Corridor,
     Elevator,
 }
 
-#[derive(Component, Inspectable)]
+#[derive(Component, Reflect)]
 pub struct CharacterLocation(pub LevelOneLocation);
 
 // /// DOC
@@ -101,20 +89,20 @@ pub struct CharacterLocation(pub LevelOneLocation);
 fn despawn_level_one(
     // mut commands: Commands,
     mut query: Query<
-        (Entity, &mut Visibility, &Name), 
+        (Entity, &mut Visibility, &Name),
         Or<(
             With<Player>,
             With<NPC>,
             With<Location>,
             With<Button>,
-            With<PushButton>
-        )>
-    >
+            With<PushButton>,
+        )>,
+    >,
 ) {
     for (_entity, mut visibility, name) in query.iter_mut() {
         // commands.entity(entity).despawn_recursive();
         info!("{} is invisible", name);
-        *visibility = Visibility::INVISIBLE;
+        *visibility = Visibility::Hidden;
     }
 }
 
@@ -128,253 +116,253 @@ fn setup_level_one(
     let walls = asset_server.load("textures/level_one/lab_wall.png");
     let floor = asset_server.load("textures/level_one/lab_floor.png");
 
-    commands.spawn((
-        TransformBundle::default(),
-        VisibilityBundle::default(),
-        Location::Level1000,
-        Name::new("LevelOne"),
-    )).with_children(|parent| {
-        parent.spawn((
-            SpriteBundle {
-                texture: floor.clone(),
-                transform: Transform {
-                    translation: FLOOR_POSITION.into(),
-                    scale: LEVEL_SCALE.into(),
-                    ..default()
-                },
-                ..SpriteBundle::default()
-            },
-            RigidBody::Fixed,
-            Name::new("floor"),
-        ));
-    
-        parent
-            .spawn((
+    commands
+        .spawn((
+            TransformBundle::default(),
+            VisibilityBundle::default(),
+            Location::Level1000,
+            Name::new("LevelOne"),
+        ))
+        .with_children(|parent| {
+            parent.spawn((
                 SpriteBundle {
-                    texture: walls.clone(),
+                    texture: floor.clone(),
                     transform: Transform {
-                        translation: LEVEL_POSITION.into(),
+                        translation: FLOOR_POSITION.into(),
                         scale: LEVEL_SCALE.into(),
                         ..default()
                     },
                     ..SpriteBundle::default()
                 },
                 RigidBody::Fixed,
-                Name::new("walls"),
-            ))
-            .with_children(|parent| {
-                // Collider draw by hand...
-                parent.spawn((
-                    Collider::cuboid(21., 1.5),
-                    Transform::from_xyz(5., -57., 0.),
-                    Name::new("Entry Lower Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(1.5, 12.),
-                    Transform::from_xyz(24.5, -46.5, 0.),
-                    Name::new("Entry Left Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(1.5, 12.),
-                    Transform::from_xyz(-14.5, -46.5, 0.),
-                    Name::new("Entry Right Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(7.5, 1.5),
-                    Transform::from_xyz(18.5, -36., 0.),
-                    Name::new("Entry Top Left Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(7.5, 1.5),
-                    Transform::from_xyz(-8.5, -36., 0.),
-                    Name::new("Entry Top Right Hitbox"),
-                ));
-                // --- Corridor ---
-                parent.spawn((
-                    Collider::cuboid(1.5, 44.5),
-                    Transform::from_xyz(12.5, 10., 0.),
-                    Name::new("Corridor Left Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(1.5, 16.5),
-                    Transform::from_xyz(-2.5, -18., 0.),
-                    Name::new("Corridor Right Bottom Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(1.5, 20.5),
-                    Transform::from_xyz(-2.5, 34., 0.),
-                    Name::new("Corridor Right Top Hitbox"),
-                ));
-                // --- Elevator ---
-                // Which is the two Exit and Front Door
-                parent.spawn((
-                    Collider::cuboid(6., 1.5),
-                    Transform::from_xyz(5., 53., 0.),
-                    Name::new("Elevator Top Hitbox"),
-                ));
-                // --- Broom Closet ---
-                parent.spawn((
-                    Collider::cuboid(1.5, 7.5),
-                    Transform::from_xyz(-29.5, 6., 0.),
-                    Name::new("Closet Left Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(12., 1.5),
-                    Transform::from_xyz(-16., 15., 0.),
-                    Name::new("Closet Top Hitbox"),
-                ));
-                parent.spawn((
-                    Collider::cuboid(12., 1.5),
-                    Transform::from_xyz(-16., -3., 0.),
-                    Name::new("Closet Bottom Hitbox"),
-                ));
-                // --- Closet Button Sensor ---
-                parent.spawn((
-                    Collider::cuboid(2.5, 3.5),
-                    Transform::from_translation(BUTTON_SENSOR_POSITION.into()),
-                    ActiveEvents::COLLISION_EVENTS,
-                    Sensor,
-                    ButtonSensor,
-                    // DOC: Better Naming
-                    Name::new("OneWay Button Sensor"),
-                ));
-            });
-  
+                Name::new("floor"),
+            ));
 
-        // -- Doors --
+            parent
+                .spawn((
+                    SpriteBundle {
+                        texture: walls.clone(),
+                        transform: Transform {
+                            translation: LEVEL_POSITION.into(),
+                            scale: LEVEL_SCALE.into(),
+                            ..default()
+                        },
+                        ..SpriteBundle::default()
+                    },
+                    RigidBody::Fixed,
+                    Name::new("walls"),
+                ))
+                .with_children(|parent| {
+                    // Collider draw by hand...
+                    parent.spawn((
+                        Collider::cuboid(21., 1.5),
+                        Transform::from_xyz(5., -57., 0.),
+                        Name::new("Entry Lower Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(1.5, 12.),
+                        Transform::from_xyz(24.5, -46.5, 0.),
+                        Name::new("Entry Left Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(1.5, 12.),
+                        Transform::from_xyz(-14.5, -46.5, 0.),
+                        Name::new("Entry Right Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(7.5, 1.5),
+                        Transform::from_xyz(18.5, -36., 0.),
+                        Name::new("Entry Top Left Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(7.5, 1.5),
+                        Transform::from_xyz(-8.5, -36., 0.),
+                        Name::new("Entry Top Right Hitbox"),
+                    ));
+                    // --- Corridor ---
+                    parent.spawn((
+                        Collider::cuboid(1.5, 44.5),
+                        Transform::from_xyz(12.5, 10., 0.),
+                        Name::new("Corridor Left Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(1.5, 16.5),
+                        Transform::from_xyz(-2.5, -18., 0.),
+                        Name::new("Corridor Right Bottom Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(1.5, 20.5),
+                        Transform::from_xyz(-2.5, 34., 0.),
+                        Name::new("Corridor Right Top Hitbox"),
+                    ));
+                    // --- Elevator ---
+                    // Which is the two Exit and Front Door
+                    parent.spawn((
+                        Collider::cuboid(6., 1.5),
+                        Transform::from_xyz(5., 53., 0.),
+                        Name::new("Elevator Top Hitbox"),
+                    ));
+                    // --- Broom Closet ---
+                    parent.spawn((
+                        Collider::cuboid(1.5, 7.5),
+                        Transform::from_xyz(-29.5, 6., 0.),
+                        Name::new("Closet Left Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(12., 1.5),
+                        Transform::from_xyz(-16., 15., 0.),
+                        Name::new("Closet Top Hitbox"),
+                    ));
+                    parent.spawn((
+                        Collider::cuboid(12., 1.5),
+                        Transform::from_xyz(-16., -3., 0.),
+                        Name::new("Closet Bottom Hitbox"),
+                    ));
+                    // --- Closet Button Sensor ---
+                    parent.spawn((
+                        Collider::cuboid(2.5, 3.5),
+                        Transform::from_translation(BUTTON_SENSOR_POSITION.into()),
+                        ActiveEvents::COLLISION_EVENTS,
+                        Sensor,
+                        ButtonSensor,
+                        // DOC: Better Naming
+                        Name::new("OneWay Button Sensor"),
+                    ));
+                });
 
-        let horizontal_door = asset_server.load("textures/level_one/horizontal_door_anim.png");
-        let horizontal_door_atlas =
-            TextureAtlas::from_grid(horizontal_door, Vec2::new(12., 3.), 1, 7, None, None);
+            // -- Doors --
 
-        let horizontal_door_atlas_handle = texture_atlases.add(horizontal_door_atlas);
-        let horizontal_door_texture_atlas_sprite = TextureAtlasSprite::new(0);
-        parent
-            .spawn((
-                SpriteSheetBundle {
-                    texture_atlas: horizontal_door_atlas_handle.clone(),
-                    sprite: horizontal_door_texture_atlas_sprite.clone(),
-                    transform: Transform {
-                        translation: IN_DOOR_POSITION.into(),
-                        scale: LEVEL_SCALE.into(),
+            let horizontal_door = asset_server.load("textures/level_one/horizontal_door_anim.png");
+            let horizontal_door_atlas =
+                TextureAtlas::from_grid(horizontal_door, Vec2::new(12., 3.), 1, 7, None, None);
+
+            let horizontal_door_atlas_handle = texture_atlases.add(horizontal_door_atlas);
+            let horizontal_door_texture_atlas_sprite = TextureAtlasSprite::new(0);
+            parent
+                .spawn((
+                    SpriteSheetBundle {
+                        texture_atlas: horizontal_door_atlas_handle.clone(),
+                        sprite: horizontal_door_texture_atlas_sprite.clone(),
+                        transform: Transform {
+                            translation: IN_DOOR_POSITION.into(),
+                            scale: LEVEL_SCALE.into(),
+                            ..default()
+                        },
                         ..default()
                     },
-                    ..default()
-                },
-                Name::new("Front Door"),
-                Door {
-                    current_state: doors::DoorState::Closed,
-                },
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Collider::cuboid(6., 1.5),
-                    Transform::default(), // from_xyz(5., -36., 0.),
-                    DoorHitbox,
-                    Name::new("Front Door Hitbox"),
-                ));
-                // --- Corridor Sensor ---
-                parent.spawn((
-                    Collider::cuboid(6., 3.),
-                    Transform::from_xyz(0., -4.5, 0.),
-                    ActiveEvents::COLLISION_EVENTS,
-                    Sensor,
-                    LocationSensor {
-                        location: LevelOneLocation::Corridor,
+                    Name::new("Front Door"),
+                    Door {
+                        current_state: doors::DoorState::Closed,
                     },
-                    Name::new("Corridor Sensor From Spawn"),
-                ));
-                // --- SpawnRoom Sensor ---
-                parent.spawn((
-                    Collider::cuboid(6., 3.),
-                    Transform::from_xyz(0., 4.5, 0.),
-                    ActiveEvents::COLLISION_EVENTS,
-                    Sensor,
-                    LocationSensor {
-                        location: LevelOneLocation::SpawnRoom,
-                    },
-                    Name::new("SpawnRoom Sensor"),
-                ));
-            });
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Collider::cuboid(6., 1.5),
+                        Transform::default(), // from_xyz(5., -36., 0.),
+                        DoorHitbox,
+                        Name::new("Front Door Hitbox"),
+                    ));
+                    // --- Corridor Sensor ---
+                    parent.spawn((
+                        Collider::cuboid(6., 3.),
+                        Transform::from_xyz(0., -4.5, 0.),
+                        ActiveEvents::COLLISION_EVENTS,
+                        Sensor,
+                        LocationSensor {
+                            location: LevelOneLocation::Corridor,
+                        },
+                        Name::new("Corridor Sensor From Spawn"),
+                    ));
+                    // --- SpawnRoom Sensor ---
+                    parent.spawn((
+                        Collider::cuboid(6., 3.),
+                        Transform::from_xyz(0., 4.5, 0.),
+                        ActiveEvents::COLLISION_EVENTS,
+                        Sensor,
+                        LocationSensor {
+                            location: LevelOneLocation::SpawnRoom,
+                        },
+                        Name::new("SpawnRoom Sensor"),
+                    ));
+                });
 
-        parent
-            .spawn((
-                SpriteSheetBundle {
-                    texture_atlas: horizontal_door_atlas_handle.clone(),
-                    sprite: horizontal_door_texture_atlas_sprite.clone(),
-                    transform: Transform {
-                        translation: OUT_DOOR_POSITION.into(),
-                        scale: LEVEL_SCALE.into(),
+            parent
+                .spawn((
+                    SpriteSheetBundle {
+                        texture_atlas: horizontal_door_atlas_handle.clone(),
+                        sprite: horizontal_door_texture_atlas_sprite.clone(),
+                        transform: Transform {
+                            translation: OUT_DOOR_POSITION.into(),
+                            scale: LEVEL_SCALE.into(),
+                            ..default()
+                        },
                         ..default()
                     },
-                    ..default()
-                },
-                Name::new("Exit Door"),
-                ExitDoor,
-                Door {
-                    current_state: doors::DoorState::Closed,
-                },
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Collider::cuboid(6., 1.5),
-                    Transform::default(), // from_xyz(5., 36., 0.),
-                    DoorHitbox,
-                    Name::new("Exit Door Hitbox"),
-                ));
-                // --- Win Sensor ---
-                parent.spawn((
-                    Collider::cuboid(4., 4.), // segment(Vect::new(9., 48.5), Vect::new(1., 40.5)),
-                    Transform::from_xyz(0., 8.5, 0.), // default(),
-                    ActiveEvents::COLLISION_EVENTS,
-                    Sensor,
-                    WinSensor,
-                    Name::new("Elevator Sensor"),
-                ));
-                // --- Corridor Sensor ---
-                parent.spawn((
-                    Collider::cuboid(6., 3.),
-                    Transform::from_xyz(0., 4.5, 0.),
-                    ActiveEvents::COLLISION_EVENTS,
-                    Sensor,
-                    LocationSensor {
-                        location: LevelOneLocation::Corridor,
+                    Name::new("Exit Door"),
+                    ExitDoor,
+                    Door {
+                        current_state: doors::DoorState::Closed,
                     },
-                    Name::new("Corridor Sensor From Exit"),
-                ));
-            });
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Collider::cuboid(6., 1.5),
+                        Transform::default(), // from_xyz(5., 36., 0.),
+                        DoorHitbox,
+                        Name::new("Exit Door Hitbox"),
+                    ));
+                    // --- Win Sensor ---
+                    parent.spawn((
+                        Collider::cuboid(4., 4.), // segment(Vect::new(9., 48.5), Vect::new(1., 40.5)),
+                        Transform::from_xyz(0., 8.5, 0.), // default(),
+                        ActiveEvents::COLLISION_EVENTS,
+                        Sensor,
+                        WinSensor,
+                        Name::new("Elevator Sensor"),
+                    ));
+                    // --- Corridor Sensor ---
+                    parent.spawn((
+                        Collider::cuboid(6., 3.),
+                        Transform::from_xyz(0., 4.5, 0.),
+                        ActiveEvents::COLLISION_EVENTS,
+                        Sensor,
+                        LocationSensor {
+                            location: LevelOneLocation::Corridor,
+                        },
+                        Name::new("Corridor Sensor From Exit"),
+                    ));
+                });
 
-        let vertical_door = asset_server.load("textures/level_one/vertical_door_anim.png");
-        let vertical_door_atlas =
-            TextureAtlas::from_grid(vertical_door, Vec2::new(3., 15.), 9, 1, None, None);
+            let vertical_door = asset_server.load("textures/level_one/vertical_door_anim.png");
+            let vertical_door_atlas =
+                TextureAtlas::from_grid(vertical_door, Vec2::new(3., 15.), 9, 1, None, None);
 
-        let vertical_door_atlas_handle = texture_atlases.add(vertical_door_atlas);
+            let vertical_door_atlas_handle = texture_atlases.add(vertical_door_atlas);
 
-        parent
-            .spawn((
-                SpriteSheetBundle {
-                    texture_atlas: vertical_door_atlas_handle,
-                    transform: Transform {
-                        translation: ALT_DOOR_POSITION.into(),
-                        scale: LEVEL_SCALE.into(),
+            parent
+                .spawn((
+                    SpriteSheetBundle {
+                        texture_atlas: vertical_door_atlas_handle,
+                        transform: Transform {
+                            translation: ALT_DOOR_POSITION.into(),
+                            scale: LEVEL_SCALE.into(),
+                            ..default()
+                        },
                         ..default()
                     },
-                    ..default()
-                },
-                Name::new("Closet Door"),
-                Door {
-                    current_state: doors::DoorState::Closed,
-                },
-                Hackable,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Collider::cuboid(1.5, 7.5),
-                    Transform::default(), // from_xyz(-2.5, 6., 0.),
-                    DoorHitbox,
-                    Name::new("Side Door Hitbox"),
-                ));
-            });
-
+                    Name::new("Closet Door"),
+                    Door {
+                        current_state: doors::DoorState::Closed,
+                    },
+                    Hackable,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Collider::cuboid(1.5, 7.5),
+                        Transform::default(), // from_xyz(-2.5, 6., 0.),
+                        DoorHitbox,
+                        Name::new("Side Door Hitbox"),
+                    ));
+                });
         });
 }

--- a/src/locations/level_one/mod.rs
+++ b/src/locations/level_one/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     locations::{
         level_one::{
             button::PushButton,
-            doors::{animate_door, open_door_event, Door, ExitDoor, OpenDoorEvent},
+            doors::{Door, ExitDoor, OpenDoorEvent},
         },
         sensors::WinSensor,
         Location,
@@ -30,16 +30,14 @@ pub mod doors;
 pub struct LevelOnePlugin;
 
 impl Plugin for LevelOnePlugin {
-    // #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app.add_event::<OpenDoorEvent>()
             // .add_event::<ResetLevelOneEvent>()
             // .add_event::<EnterLevelOneEvent>()
-            // .add_system(reset_level_one)
-            // .add_system(enter_level_one)
+            // .add_systems((reset_level_one, enter_level_one))
             .add_systems((setup_level_one, set_up_button).in_schedule(OnEnter(Location::Level1000)))
             .add_systems(
-                (animate_door, open_door_event).in_set(OnUpdate(Location::Level1000)), // .run_if(in_level_one)
+                (doors::animate_door, doors::open_door_event).in_set(OnUpdate(Location::Level1000)), // .run_if(in_level_one)
             )
             .add_system(despawn_level_one.in_schedule(OnExit(Location::Level1000)));
     }

--- a/src/locations/mod.rs
+++ b/src/locations/mod.rs
@@ -30,16 +30,23 @@ impl Plugin for LocationsPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<WinTriggerEvent>()
             .add_state::<Location>()
-            .add_plugin(level_one::LevelOnePlugin)
-            .add_systems((
-                sensors::win_trigger,
-                sensors::win_event,
-                sensors::location_event,
-                sensors::button_event,
-            ))
+            .add_plugins(level_one::LevelOnePlugin)
             .add_systems(
-                (spawn_cinematic_final, cinematic_camera).in_schedule(OnEnter(Location::OutDoor)),
+                Update,
+                (
+                    sensors::win_trigger,
+                    sensors::win_event,
+                    sensors::location_event,
+                    sensors::button_event,
+                ),
             )
-            .add_systems((animate_clouds, animate_free_cat).in_set(OnUpdate(Location::OutDoor)));
+            .add_systems(
+                OnEnter(Location::OutDoor),
+                (spawn_cinematic_final, cinematic_camera),
+            )
+            .add_systems(
+                Update,
+                (animate_clouds, animate_free_cat).run_if(in_state(Location::OutDoor)),
+            );
     }
 }

--- a/src/locations/mod.rs
+++ b/src/locations/mod.rs
@@ -1,19 +1,8 @@
 use bevy::prelude::*;
 
 use self::{
-    cinematics::{
-        animate_clouds,
-        animate_free_cat,
-        cinematic_camera,
-        spawn_cinematic_final,
-    },
-    sensors::{
-        button_event,
-        location_event,
-        win_trigger,
-        win_event,
-        WinTriggerEvent
-    },
+    cinematics::{animate_clouds, animate_free_cat, cinematic_camera, spawn_cinematic_final},
+    sensors::WinTriggerEvent,
 };
 
 pub mod cinematics;
@@ -22,10 +11,10 @@ pub mod sensors;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, Component, States)]
 pub enum Location {
-    // /// The transition universe
-    // /// Used when reset a Level
-    // Void,
-    // Start cinematic
+    /// The transition universe
+    /// Used when reset a Level
+    Void,
+    StartCinematic,
     #[default]
     Level1000,
     LevelTwo,
@@ -38,25 +27,19 @@ pub enum Location {
 pub struct LocationsPlugin;
 
 impl Plugin for LocationsPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app .add_event::<WinTriggerEvent>()
+        app.add_event::<WinTriggerEvent>()
             .add_state::<Location>()
             .add_plugin(level_one::LevelOnePlugin)
-
-            .add_system(win_trigger)
-            .add_system(win_event)
-            .add_system(location_event)
-            .add_system(button_event)
-            
+            .add_systems((
+                sensors::win_trigger,
+                sensors::win_event,
+                sensors::location_event,
+                sensors::button_event,
+            ))
             .add_systems(
-                (spawn_cinematic_final, cinematic_camera)
-                    .in_schedule(OnEnter(Location::OutDoor))
+                (spawn_cinematic_final, cinematic_camera).in_schedule(OnEnter(Location::OutDoor)),
             )
-            .add_systems(
-                (animate_clouds, animate_free_cat)
-                    .in_set(OnUpdate(Location::OutDoor))
-            )
-            ;
+            .add_systems((animate_clouds, animate_free_cat).in_set(OnUpdate(Location::OutDoor)));
     }
 }

--- a/src/locations/mod.rs
+++ b/src/locations/mod.rs
@@ -20,12 +20,13 @@ pub mod cinematics;
 pub mod level_one;
 pub mod sensors;
 
-#[derive(Component, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, Component, States)]
 pub enum Location {
     // /// The transition universe
     // /// Used when reset a Level
     // Void,
     // Start cinematic
+    #[default]
     Level1000,
     LevelTwo,
     LevelOne,
@@ -40,25 +41,21 @@ impl Plugin for LocationsPlugin {
     #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app .add_event::<WinTriggerEvent>()
-
+            .add_state::<Location>()
             .add_plugin(level_one::LevelOnePlugin)
-
-            .add_state(Location::Level1000)
 
             .add_system(win_trigger)
             .add_system(win_event)
             .add_system(location_event)
             .add_system(button_event)
             
-            .add_system_set(
-                SystemSet::on_enter(Location::OutDoor)
-                    .with_system(spawn_cinematic_final)
-                    .with_system(cinematic_camera)
+            .add_systems(
+                (spawn_cinematic_final, cinematic_camera)
+                    .in_schedule(OnEnter(Location::OutDoor))
             )
-            .add_system_set(
-                SystemSet::on_update(Location::OutDoor)
-                    .with_system(animate_clouds)
-                    .with_system(animate_free_cat)
+            .add_systems(
+                (animate_clouds, animate_free_cat)
+                    .in_set(OnUpdate(Location::OutDoor))
             )
             ;
     }

--- a/src/locations/sensors.rs
+++ b/src/locations/sensors.rs
@@ -19,7 +19,8 @@ use crate::{
 ///   -
 /// Read in
 ///   -
-/// DOC
+/// DOC: describe WinTriggerEvent
+#[derive(Event)]
 pub struct WinTriggerEvent {
     /// The Entity which triggered the WinEvent
     pub entity: Entity,
@@ -82,8 +83,7 @@ pub fn win_event(
                 println!("{}", congrats);
             }
         }
-        // TODO: "increment" the level
-        if current_location.0 == Location::Level1000 {
+        if current_location.get() == &Location::Level1000 {
             println!("In LevelOne");
             next_location.set(Location::OutDoor);
         }

--- a/src/locations/sensors.rs
+++ b/src/locations/sensors.rs
@@ -71,7 +71,8 @@ pub fn win_event(
     mut win_event: EventReader<WinTriggerEvent>,
 
     character_query: Query<&Name, Or<(With<Player>, With<NPC>)>>,
-    mut location: ResMut<State<Location>>,
+    current_location: Res<State<Location>>,
+    mut next_location: ResMut<NextState<Location>>,
 ) {
     for event in win_event.iter() {
         match character_query.get(event.entity) {
@@ -82,9 +83,9 @@ pub fn win_event(
             }
         }
         // TODO: "increment" the level
-        if *location.current() == Location::Level1000 {
+        if current_location.0 == Location::Level1000 {
             println!("In LevelOne");
-            location.set(Location::OutDoor).unwrap();
+            next_location.set(Location::OutDoor);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,8 +71,5 @@ fn spawn_camera(mut commands: Commands) {
 
     camera.projection.scale = 0.1;
 
-    // vv-- Flip the left and right --vv
-    // camera.projection.scaling_mode = ScalingMode::None;
-
     commands.spawn(camera);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,7 @@
 use bevy::{prelude::*, window::WindowResolution};
 use bevy_rapier2d::prelude::*;
 
-use characters::CharactersPlugin;
 use constants::{RESOLUTION, TILE_SIZE};
-use debug::DebugPlugin;
-use locations::LocationsPlugin;
-use spritesheet::CatSpritePlugin;
-use tablet::hack::HackPlugin;
-use tablet::mind_control::MindControlPlugin;
 
 pub mod characters;
 pub mod collisions;
@@ -21,7 +15,6 @@ pub mod locations;
 mod spritesheet;
 pub mod tablet;
 
-#[rustfmt::skip]
 fn main() {
     let height = 1080.;
 
@@ -35,8 +28,7 @@ fn main() {
             gravity: Vec2::ZERO,
             ..default()
         })
-
-        .add_plugins(
+        .add_plugins((
             DefaultPlugins
                 .set(WindowPlugin {
                     primary_window: Some(Window {
@@ -48,20 +40,22 @@ fn main() {
                     ..default()
                 })
                 .set(ImagePlugin::default_nearest()),
-        )
-        .add_plugin(RapierDebugRenderPlugin {
-            mode: DebugRenderMode::all(),
-            ..default()
-        })
-        .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(1.))
-        // .add_plugin(TweeningPlugin)
-        .add_plugin(DebugPlugin)
-        .add_plugin(CatSpritePlugin)
-        .add_plugin(HackPlugin)
-        .add_plugin(LocationsPlugin)
-        .add_plugin(MindControlPlugin)
-        .add_plugin(CharactersPlugin)
-        .add_startup_system(spawn_camera);
+            RapierDebugRenderPlugin {
+                mode: DebugRenderMode::all(),
+                ..default()
+            },
+            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(1.),
+            // TweeningPlugin,
+        ))
+        .add_plugins((
+            debug::DebugPlugin,
+            spritesheet::CatSpritePlugin,
+            tablet::hack::HackPlugin,
+            locations::LocationsPlugin,
+            tablet::mind_control::MindControlPlugin,
+            characters::CharactersPlugin,
+        ))
+        .add_systems(Startup, spawn_camera);
 
     app.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![allow(clippy::type_complexity, clippy::too_many_arguments, clippy::pedantic)]
+// #![warn(missing_docs)]
 
 use bevy::{prelude::*, render::camera::ScalingMode};
 use bevy_rapier2d::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::type_complexity, clippy::too_many_arguments, clippy::pedantic)]
 // #![warn(missing_docs)]
 
-use bevy::{prelude::*, render::camera::ScalingMode};
+use bevy::{prelude::*, window::WindowResolution};
 use bevy_rapier2d::prelude::*;
 
 use characters::CharactersPlugin;
@@ -29,7 +29,7 @@ fn main() {
     app
         // Color::TEAL / AZURE
         .insert_resource(ClearColor(Color::TEAL))
-        .insert_resource(Msaa { samples: 1 })
+        .insert_resource(Msaa::Off)
         // v-- Hitbox --v
         .insert_resource(RapierConfiguration {
             gravity: Vec2::ZERO,
@@ -39,13 +39,12 @@ fn main() {
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {
-                    window: WindowDescriptor {
-                        width: height * RESOLUTION,
-                        height,
+                    primary_window: Some(Window {
+                        resolution: WindowResolution::new(height * RESOLUTION, height),
                         title: "CatBeDoingTheLaundry".to_string(),
                         resizable: true,
                         ..default()
-                    },
+                    }),
                     ..default()
                 })
                 .set(ImagePlugin::default_nearest()),
@@ -70,14 +69,10 @@ fn main() {
 fn spawn_camera(mut commands: Commands) {
     let mut camera = Camera2dBundle::default();
 
-    camera.projection.top = 50. * TILE_SIZE;
-    camera.projection.bottom = -50. * TILE_SIZE;
-
-    camera.projection.left = 50. * TILE_SIZE * RESOLUTION;
-    camera.projection.right = -50. * TILE_SIZE * RESOLUTION;
+    camera.projection.scale = 0.1;
 
     // vv-- Flip the left and right --vv
-    camera.projection.scaling_mode = ScalingMode::None;
+    // camera.projection.scaling_mode = ScalingMode::None;
 
     commands.spawn(camera);
 }

--- a/src/spritesheet.rs
+++ b/src/spritesheet.rs
@@ -8,7 +8,7 @@ impl Plugin for CatSpritePlugin {
     #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app
-            .add_startup_system_to_stage(StartupStage::PreStartup, load_character_spritesheet)
+            .add_startup_system(load_character_spritesheet.in_base_set(StartupSet::PreStartup))
             .add_system(animate_sprite)
             ;
     }

--- a/src/spritesheet.rs
+++ b/src/spritesheet.rs
@@ -6,18 +6,55 @@ pub struct CatSpritePlugin;
 
 impl Plugin for CatSpritePlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(load_character_spritesheet.in_base_set(StartupSet::PreStartup))
-            .add_system(animate_sprite);
+        app.init_resource::<CatSheet>()
+            .init_resource::<DazeSheet>()
+            .add_systems(Update, animate_sprite);
     }
 }
 
 #[derive(Clone, Resource)]
 pub struct CatSheet(pub Handle<TextureAtlas>);
 
+impl FromWorld for CatSheet {
+    fn from_world(world: &mut World) -> Self {
+        let image = world
+            .get_resource::<AssetServer>()
+            .unwrap()
+            .load("textures/character/character_sheet_v1.png");
+        // warn!("You have to download the asset see in github releases");
+        let atlas = TextureAtlas::from_grid(image, Vec2::splat(14.), 2, 2, None, None);
+
+        let atlas_handle = world
+            .get_resource_mut::<Assets<TextureAtlas>>()
+            .unwrap()
+            .add(atlas);
+
+        CatSheet(atlas_handle)
+    }
+}
+
 /// DOC: Rename it to EffectSheet
 #[derive(Clone, Resource)]
 pub struct DazeSheet(pub Handle<TextureAtlas>);
 
+impl FromWorld for DazeSheet {
+    fn from_world(world: &mut World) -> Self {
+        let dazed_image = world
+            .get_resource::<AssetServer>()
+            .unwrap()
+            .load("textures/character/dazed.png");
+        // warn!("You have to download the asset see in github releases");
+        let dazed_atlas =
+            TextureAtlas::from_grid(dazed_image, Vec2::from((35., 25.)), 12, 1, None, None);
+
+        let dazed_atlas_handle = world
+            .get_resource_mut::<Assets<TextureAtlas>>()
+            .unwrap()
+            .add(dazed_atlas);
+
+        DazeSheet(dazed_atlas_handle)
+    }
+}
 #[derive(Component, Deref, DerefMut)]
 pub struct AnimationTimer(pub Timer);
 
@@ -54,26 +91,4 @@ pub fn animate_sprite(
             state.current = sprite.index;
         }
     }
-}
-
-fn load_character_spritesheet(
-    mut commands: Commands,
-    assets: Res<AssetServer>,
-    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
-) {
-    let image = assets.load("textures/character/character_sheet_v1.png");
-    // warn!("You have to download the asset see in github releases");
-    let atlas = TextureAtlas::from_grid(image, Vec2::splat(14.), 2, 2, None, None);
-
-    let atlas_handle = texture_atlases.add(atlas);
-
-    commands.insert_resource(CatSheet(atlas_handle));
-
-    let dazed_image = assets.load("textures/character/dazed.png");
-    let dazed_atlas =
-        TextureAtlas::from_grid(dazed_image, Vec2::from((35., 25.)), 12, 1, None, None);
-
-    let dazed_atlas_handle = texture_atlases.add(dazed_atlas);
-
-    commands.insert_resource(DazeSheet(dazed_atlas_handle));
 }

--- a/src/spritesheet.rs
+++ b/src/spritesheet.rs
@@ -5,12 +5,9 @@ use crate::characters::{npcs::NPC, player::Player};
 pub struct CatSpritePlugin;
 
 impl Plugin for CatSpritePlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app
-            .add_startup_system(load_character_spritesheet.in_base_set(StartupSet::PreStartup))
-            .add_system(animate_sprite)
-            ;
+        app.add_startup_system(load_character_spritesheet.in_base_set(StartupSet::PreStartup))
+            .add_system(animate_sprite);
     }
 }
 

--- a/src/tablet/hack/mod.rs
+++ b/src/tablet/hack/mod.rs
@@ -1,35 +1,22 @@
 use bevy::{prelude::*, winit::WinitSettings};
 
 use crate::{
-    constants::ui::tablet::*, 
+    constants::ui::tablet::*,
     locations::level_one::doors::{Door, OpenDoorEvent},
-    tablet::{
-        run_if_tablet_is_free,
-        run_if_tablet_is_mind_ctrl,
-    }
+    tablet::{tablet_is_free, tablet_is_mind_ctrl},
 };
 
 pub struct HackPlugin;
 
 impl Plugin for HackPlugin {
-    #[rustfmt::skip]
+    // #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app
             // OPTIMIZE: Only run the app when there is user input. This will significantly reduce CPU/GPU use.
             .insert_resource(WinitSettings::game())
-            
             .add_startup_system(setup_tablet_button)
-            .add_system_set(
-                SystemSet::new()
-                    .with_run_criteria(run_if_tablet_is_free)
-                    .with_system(button_system)
-            )
-            .add_system_set(
-                SystemSet::new()
-                    .with_run_criteria(run_if_tablet_is_mind_ctrl)
-                    .with_system(place_holder_while_in_mind_control)
-            )
-            ;
+            .add_system(button_system.run_if(tablet_is_free))
+            .add_system(place_holder_while_in_mind_control.run_if(tablet_is_mind_ctrl));
     }
 }
 
@@ -80,9 +67,9 @@ pub fn setup_tablet_button(mut commands: Commands, asset_server: Res<AssetServer
 // }
 
 /// # Note
-/// 
+///
 /// Spamming should not work (cause of the timer being only 0.1s)
-/// 
+///
 /// TODO: feature - limit the access to tablet's features when using one
 /// Can't hack while MindCtrl -------------------^^^^^^^^
 /// REFACTOR: seperate color/text management from action

--- a/src/tablet/hack/mod.rs
+++ b/src/tablet/hack/mod.rs
@@ -14,9 +14,14 @@ impl Plugin for HackPlugin {
         app
             // OPTIMIZE: Only run the app when there is user input. This will significantly reduce CPU/GPU use.
             .insert_resource(WinitSettings::game())
-            .add_startup_system(setup_tablet_button)
-            .add_system(button_system.run_if(tablet_is_free))
-            .add_system(place_holder_while_in_mind_control.run_if(tablet_is_mind_ctrl));
+            .add_systems(Startup, setup_tablet_button)
+            .add_systems(
+                Update,
+                (
+                    button_system.run_if(tablet_is_free),
+                    place_holder_while_in_mind_control.run_if(tablet_is_mind_ctrl),
+                ),
+            );
     }
 }
 
@@ -29,18 +34,16 @@ pub fn setup_tablet_button(mut commands: Commands, asset_server: Res<AssetServer
         .spawn((
             ButtonBundle {
                 style: Style {
-                    size: Size::new(Val::Px(180.), Val::Px(65.)),
+                    width: Val::Px(180.),
+                    height: Val::Px(65.),
                     // center button
                     margin: UiRect::all(Val::Auto),
                     // horizontally center child text
                     justify_content: JustifyContent::Center,
                     // vertically center child text
                     align_items: AlignItems::Center,
-                    position: UiRect {
-                        right: Val::Percent(-39.),
-                        top: Val::Percent(30.),
-                        ..default()
-                    },
+                    top: Val::Percent(30.),
+                    right: Val::Percent(-39.),
                     ..default()
                 },
                 background_color: NORMAL_BUTTON.into(),
@@ -87,7 +90,7 @@ fn button_system(
     for (interaction, mut color, children) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 // hack every hackable door
                 for door in hackable_door.iter() {
                     open_door_event.send(OpenDoorEvent(door));
@@ -118,7 +121,7 @@ pub fn place_holder_while_in_mind_control(
     for (interaction, mut color, children) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 // *color = PRESSED_BUTTON.into();
             }
             Interaction::Hovered => {

--- a/src/tablet/mind_control/mod.rs
+++ b/src/tablet/mind_control/mod.rs
@@ -75,12 +75,11 @@ pub fn mind_control_button(
     npc_query: Query<Entity, With<NPC>>,
 ) {
     if keyboard_input.pressed(KeyCode::M) {
-        for npc in npc_query.iter() {
+        if let Some(npc) = npc_query.iter().next() {
             commands.entity(npc).insert(MindControled); // .remove::<Dazed>()
-            break;
+            let player = player_query.single();
+            commands.entity(player).remove::<MindControled>();
         }
-        let player = player_query.single();
-        commands.entity(player).remove::<MindControled>();
     }
 }
 
@@ -93,7 +92,6 @@ fn exit_mind_control(
     npc_query: Query<(Entity, &Name), (With<NPC>, With<MindControled>)>,
 ) {
     if keyboard_input.pressed(KeyCode::Escape) {
-        // could be a single for now
         for (npc, _name) in npc_query.iter() {
             commands.entity(npc).remove::<MindControled>();
         }

--- a/src/tablet/mind_control/mod.rs
+++ b/src/tablet/mind_control/mod.rs
@@ -18,34 +18,30 @@ pub struct MindControlPlugin;
 
 impl Plugin for MindControlPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(
-            mind_control_button
-                .run_if(tablet_is_free)
-                .in_set(MindControlSet::Enter),
+        app.add_systems(
+            Update,
+            (
+                mind_control_button
+                    .run_if(tablet_is_free)
+                    .in_set(MindControlSet::Enter),
+                exit_mind_control
+                    .run_if(tablet_is_mind_ctrl)
+                    .in_set(MindControlSet::Exit)
+                    .after(MindControlSet::Enter),
+                camera_follow
+                    .after(MindControlSet::Movement)
+                    .run_if(in_state(Location::Level1000)),
+                mind_control_movement
+                    .in_set(MindControlSet::Movement)
+                    .after(MindControlSet::Enter),
+                daze_cure_by_mind_control
+                    .before(MindControlSet::Exit)
+                    .after(MindControlSet::Enter),
+            ),
         )
-        .add_system(
-            exit_mind_control
-                .run_if(tablet_is_mind_ctrl)
-                .in_set(MindControlSet::Exit)
-                .after(MindControlSet::Enter),
-        )
-        .add_system(
-            camera_follow
-                .after(MindControlSet::Movement)
-                .in_set(OnUpdate(Location::Level1000)),
-        )
-        .add_system(
-            mind_control_movement
-                .in_set(MindControlSet::Movement)
-                .after(MindControlSet::Enter),
-        )
-        .add_system(
-            daze_post_mind_control.in_base_set(CoreSet::PostUpdate), //.after(MindControlSet::Exit)
-        )
-        .add_system(
-            daze_cure_by_mind_control
-                .before(MindControlSet::Exit)
-                .after(MindControlSet::Enter),
+        .add_systems(
+            PostUpdate,
+            daze_post_mind_control, //.after(MindControlSet::Exit)
         );
     }
 }

--- a/src/tablet/mind_control/mod.rs
+++ b/src/tablet/mind_control/mod.rs
@@ -17,7 +17,6 @@ mod movement;
 pub struct MindControlPlugin;
 
 impl Plugin for MindControlPlugin {
-    // #[rustfmt::skip]
     fn build(&self, app: &mut App) {
         app.add_system(
             mind_control_button

--- a/src/tablet/mind_control/movement.rs
+++ b/src/tablet/mind_control/movement.rs
@@ -18,7 +18,7 @@ pub fn mind_control_movement(
             || keyboard_input.pressed(KeyCode::A);
         let right = keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right);
 
-        let x_axis = -(right as i8) + left as i8;
+        let x_axis = -(left as i8) + right as i8;
         let y_axis = -(down as i8) + up as i8;
 
         let mut vel_x = x_axis as f32 * **speed;

--- a/src/tablet/mod.rs
+++ b/src/tablet/mod.rs
@@ -1,12 +1,6 @@
 use bevy::prelude::*;
 
-use crate::{
-    characters::player::Player,
-    tablet::{
-        hack::HackPlugin,
-        mind_control::{MindControlPlugin, MindControled},
-    },
-};
+use crate::{characters::player::Player, tablet::mind_control::MindControled};
 
 pub mod hack;
 pub mod mind_control;
@@ -14,24 +8,16 @@ pub mod mind_control;
 pub struct TabletPlugin;
 
 impl Plugin for TabletPlugin {
-    #[rustfmt::skip]
     fn build(&self, app: &mut App) {
-        app
-            .add_plugin(MindControlPlugin)
-            .add_plugin(HackPlugin)
-            ;
+        app.add_plugins((mind_control::MindControlPlugin, hack::HackPlugin));
     }
 }
 
 /// REFACTOR: stop checking if free by the Entity Player not being MindControled ?
-fn tablet_is_free(
-    player_query: Query<Entity, (With<MindControled>, With<Player>)>,
-) -> bool {
+fn tablet_is_free(player_query: Query<Entity, (With<MindControled>, With<Player>)>) -> bool {
     player_query.get_single().is_ok()
 }
 
-fn tablet_is_mind_ctrl(
-    player_query: Query<Entity, (With<MindControled>, With<Player>)>,
-) -> bool {
+fn tablet_is_mind_ctrl(player_query: Query<Entity, (With<MindControled>, With<Player>)>) -> bool {
     player_query.get_single().is_err()
 }

--- a/src/tablet/mod.rs
+++ b/src/tablet/mod.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ShouldRun, prelude::*};
+use bevy::prelude::*;
 
 use crate::{
     characters::player::Player,
@@ -24,20 +24,14 @@ impl Plugin for TabletPlugin {
 }
 
 /// REFACTOR: stop checking if free by the Entity Player not being MindControled ?
-fn run_if_tablet_is_free(
+fn tablet_is_free(
     player_query: Query<Entity, (With<MindControled>, With<Player>)>,
-) -> ShouldRun {
-    match player_query.get_single() {
-        Ok(_) => ShouldRun::Yes,
-        _ => ShouldRun::No,
-    }
+) -> bool {
+    player_query.get_single().is_ok()
 }
 
-fn run_if_tablet_is_mind_ctrl(
+fn tablet_is_mind_ctrl(
     player_query: Query<Entity, (With<MindControled>, With<Player>)>,
-) -> ShouldRun {
-    match player_query.get_single() {
-        Ok(_) => ShouldRun::No,
-        _ => ShouldRun::Yes,
-    }
+) -> bool {
+    player_query.get_single().is_err()
 }


### PR DESCRIPTION
## Bevy Migration - [v0.3.0](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0) - 2024-08-06

[![v0.3.0](https://img.shields.io/badge/v0.3.0-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)](https://github.com/Fabinistere/cats_destroyer_2000/releases/tag/v0.3.0)
[![**Full Commits History**](https://img.shields.io/badge/GitHubLog-gray?style=flat&logo=github&logoColor=181717&link=https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)](https://github.com/fabinistere/cats_destroyer_2000/commits/v0.3.0)

- [Migration Guide Bevy 0.10 -> 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/)
- *not needed* [Changelog Bevy Rapier 0.21 -> 0.22](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0220-10-july-2023)

### Added

- [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/fabinistere/cats_destroyer_2000#license)

### [Bevy 0.11](https://bevyengine.org/learn/migration-guides/0.10-0.11/) Migration

- ECS
  - `in_set(OnUpdate(*))` -> `run_if(in_state(*))`
  - Add the `#[derive(Event)]` macro for events.
  - Allow tuples and single plugins in `add_plugins`, deprecate `add_plugin`
  - [Schedule-First: the new and improved `add_systems`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#schedule-first-the-new-and-improved-add-systems)
- UI
  - Flatten UI Style properties that use Size + remove Size
    - The `size`, `min_size`, `max_size`, and `gap` properties have been replaced by the `width`, `height`, `min_width`, `min_height`, `max_width`, `max_height`, `row_gap`, and `column_gap` properties. Use the new properties instead.
  - [Remove `Val::Undefinded`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#remove-val-undefined)
    - `Val::Undefined` has been removed. Bevy UI’s behaviour with default values should remain the same.
    The default values of `UiRect`’s fields have been changed to `Val::Px(0.)`.
    `Style`’s position field has been removed. Its `left`, `right`, `top` and `bottom` fields have been added to `Style` directly.
    For the `size`, `margin`, `border`, and `padding` fields of `Style`, `Val::Undefined` should be replaced with `Val::Px(0.)`.
    For the `min_size`, `max_size`, `left`, `right`, `top` and `bottom` fields of `Style`, `Val::Undefined` should be replaced with `Val::Auto`
  - [Rename keys like `LAlt` to `AltLeft`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#rename-keys-like-lalt-to-altleft)
  - [Delay asset hot reloading](https://bevyengine.org/learn/migration-guides/0.10-0.11/#delay-asset-hot-reloading)
  - [`Interaction::Clicked` replaced by `Interaction::Pressed`](https://bevyengine.org/learn/migration-guides/0.10-0.11/#rename-interaction-clicked-interaction-pressed)
- Dependencies
  - bevy_rapier_2d `0.22`
  - bevy-inspector-egui `0.20`

### [Bevy 0.10](https://bevyengine.org/learn/migration-guides/0.9-0.10/) Migration

- Dependencies
  - remove the `dynamic` feature fr
  - bevy-inspector-egui `0.18`
  - bevy_rapier2d `0.21` - [changelog](https://github.com/dimforge/bevy_rapier/blob/master/CHANGELOG.md#0210--07-march-2023)
    - feature `debug-render` change to `debug-render-2d`
- ECS
  - [Migrate engine to Schedule v3 (stageless)](https://bevyengine.org/learn/migration-guides/0.9-0.10/#migrate-engine-to-schedule-v3-stageless)
  - [System sets (Bevy 0.9)](https://bevyengine.org/learn/migration-guides/0.9-0.10/#system-sets-bevy-0-9)
  - [States](https://bevyengine.org/learn/migration-guides/0.9-0.10/#states)
  - Replace `RemovedComponents<T>` backing with `Events<Entity>`
- UI
  - [Windows as Entities](https://bevyengine.org/learn/migration-guides/0.9-0.10/#windows-as-entities)

